### PR TITLE
Encode output text as UTF-8

### DIFF
--- a/modules/svneverever/main.py
+++ b/modules/svneverever/main.py
@@ -59,9 +59,9 @@ def dump_tree(t, revision_digits, latest_revision, config, level=0, branch_level
 		else:
 			level_text = ' '*(4*level)
 		if config.show_numbers:
-			print('%s  %s%s' % (line_start, level_text, text))
+			print('%s  %s%s' % (line_start, level_text, text.encode('utf-8')))
 		else:
-			print('%s%s' % (level_text, text))
+			print('%s%s' % (level_text, text.encode('utf-8')))
 
 	items = ((k, v) for k, v in t.items() if k)
 


### PR DESCRIPTION
If the output is not UTF-8 encoded, I get the following error with one of the repos I analyzed:

Traceback (most recent call last):
  File "/usr/local/bin/svneverever", line 17, in <module>
    main()
  File "/usr/local/lib/python2.7/dist-packages/svneverever/main.py", line 307, in main
    dump_tree(tree, digit_count(latest_revision), latest_revision, config=args)
  File "/usr/local/lib/python2.7/dist-packages/svneverever/main.py", line 92, in dump_tree
    dump_tree(children, revision_digits, latest_revision, config, level=level + 1, branch_level=bl, tag_level=tl, parent_dir= '%s/%s' % (parent_dir, k))
  File "/usr/local/lib/python2.7/dist-packages/svneverever/main.py", line 92, in dump_tree
    dump_tree(children, revision_digits, latest_revision, config, level=level + 1, branch_level=bl, tag_level=tl, parent_dir= '%s/%s' % (parent_dir, k))
  File "/usr/local/lib/python2.7/dist-packages/svneverever/main.py", line 92, in dump_tree
    dump_tree(children, revision_digits, latest_revision, config, level=level + 1, branch_level=bl, tag_level=tl, parent_dir= '%s/%s' % (parent_dir, k))
  File "/usr/local/lib/python2.7/dist-packages/svneverever/main.py", line 92, in dump_tree
    dump_tree(children, revision_digits, latest_revision, config, level=level + 1, branch_level=bl, tag_level=tl, parent_dir= '%s/%s' % (parent_dir, k))
  File "/usr/local/lib/python2.7/dist-packages/svneverever/main.py", line 84, in dump_tree
    indent_print(visual_rev, '/%s' % k)
  File "/usr/local/lib/python2.7/dist-packages/svneverever/main.py", line 62, in indent_print
    print('%s  %s%s' % (line_start, level_text, text))
UnicodeEncodeError: 'ascii' codec can't encode character u'\xfc' in position 33: ordinal not in range(128)