### PR TITLE
Fix CI / `run-tests.yml`: Ensure availability of command `svnadmin`

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,8 @@ jobs:
         run: |-
           sudo apt-get update
           sudo apt-get install --yes --no-install-recommends -V \
-              python3-svn
+              python3-svn \
+              subversion
 
       - name: Install svneverever
         run: |-


### PR DESCRIPTION
.. now that package `python3-svn` seems to no longer depend on package `subversion`.